### PR TITLE
Add batch_size argument in TFLiteRunner.reset_state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,8 +36,11 @@ Release history
 
 - Renamed ``tflite_runner.Runner`` to ``TFLiteRunner``. (`#4`_)
 - Renamed ``saved_model_runner.Runner`` to ``SavedModelRunner``. (`#4`_)
+- ``TFLiteRunner.reset_state`` now takes a ``batch_size`` argument, which can be used
+  to prepare the model to run with different batch sizes. (`#5`_)
 
 .. _#4: https://github.com/nengo/nengo-edge/pull/4
+.. _#5: https://github.com/nengo/nengo-edge/pull/5
 
 23.2.23 (February 23, 2023)
 ===========================

--- a/nengo_edge/tflite_runner.py
+++ b/nengo_edge/tflite_runner.py
@@ -45,11 +45,11 @@ class TFLiteRunner:
 
         self.reset_state()
 
-    def reset_state(self) -> None:
+    def reset_state(self, batch_size: int = 1) -> None:
         """Reset the internal state of the model to initial conditions."""
         assert self.model_interpreter is not None
         self.model_state = [
-            np.zeros(x["shape"], dtype=x["dtype"])
+            np.zeros([batch_size] + x["shape"].tolist()[1:], dtype=x["dtype"])
             for x in self.model_interpreter.get_input_details()[1:]
         ]
 
@@ -58,8 +58,10 @@ class TFLiteRunner:
                 np.zeros(
                     [
                         # initialize dynamic state sizes to 0 to avoid startup artifacts
-                        0 if sig == -1 else val
-                        for sig, val in zip(x["shape_signature"], x["shape"])
+                        batch_size if i == 0 else (0 if sig == -1 else val)
+                        for i, (sig, val) in enumerate(
+                            zip(x["shape_signature"], x["shape"])
+                        )
                     ],
                     dtype=x["dtype"],
                 )


### PR DESCRIPTION
This allows us to dynamically run the model with variable batch sizes (as long as `reset_state` is called whenever we want to change the batch size).