### PR TITLE
Move rich to a base requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
           path: nengo-edge
       - uses: actions/checkout@v3
         with:
+          repository: nengo/state-space
+          path: state-space
+          token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
           repository: nengo/nengo-edge-models
           path: nengo-edge-models
           token: ${{ secrets.GH_TOKEN }}
@@ -95,6 +100,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - name: Install NengoEdge libraries
         run: |
+          pip install ../state-space
           pip install ../nengo-edge-models
           pip install ../nengo-edge-hw
       - name: DVC setup

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -37,6 +37,7 @@ setup_py:
   install_req:
     - packaging>=20.9
     - pyserial>=3.5
+    - rich>=13.3.1
     - tensorflow>=2.10.0 # TODO: support earlier versions?
   tests_req:
     - mypy>=0.901
@@ -47,7 +48,6 @@ setup_py:
     - nbsphinx>=0.8.11
     - nengo-sphinx-theme>=20.9
     - numpydoc>=1.4.0
-    - rich>=13.3.1
     - sounddevice>=0.4.5
     - sphinx-tabs~=3.2.0 # more recent versions are incompatible with sphinx 3
   url: https://github.com/nengo/nengo-edge

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,7 +44,7 @@ we recommend using Mamba.
       to run NengoEdge models by installing from the ``conda-forge`` channel.
 
       1. Download the
-         `Miniconda installer <https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links>`_
+         `Miniconda installer <https://docs.conda.io/projects/miniconda/en/latest/#latest-miniconda-installer-links>`_
          for your OS and follow the installation instructions on that page.
 
       2. Open a terminal or command-line prompt and ensure conda is up to date.

--- a/nengo_edge/tests/test_saved_model_runner.py
+++ b/nengo_edge/tests/test_saved_model_runner.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from nengo_edge_hw import gpu
-from nengo_edge_models.asr.models import conformer_tiny
+from nengo_edge_models.asr.models import lmuformer_tiny
 from nengo_edge_models.kws.models import lmu_small
 from nengo_edge_models.models import MFCC
 
@@ -51,7 +51,7 @@ def test_runner_ragged(
 ) -> None:
     tf.keras.utils.set_random_seed(seed)
 
-    pipeline = conformer_tiny()
+    pipeline = lmuformer_tiny()
     if mode == "feature-only":
         pipeline.model = []
     elif mode == "model-only":

--- a/nengo_edge/version.py
+++ b/nengo_edge/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 8, 2)  # bones: ignore
+version_info = (23, 8, 29)  # bones: ignore
 
 name = "nengo-edge"
 dev = 0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ version = runpy.run_path(str(root / "nengo_edge" / "version.py"))["version"]
 install_req = [
     "packaging>=20.9",
     "pyserial>=3.5",
+    "rich>=13.3.1",
     "tensorflow>=2.10.0",
 ]
 docs_req = [
@@ -39,7 +40,6 @@ docs_req = [
     "nbsphinx>=0.8.11",
     "nengo-sphinx-theme>=20.9",
     "numpydoc>=1.4.0",
-    "rich>=13.3.1",
     "sounddevice>=0.4.5",
     "sphinx-tabs~=3.2.0",
 ]


### PR DESCRIPTION
It's required by MicroRunner, so it isn't a docs-only requirement. This wasn't caught by CI because we install `dvc`, which also has a `rich` requirement.