### PR TITLE
Add cli for validating dataset uploads

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -12,6 +12,7 @@ setup_cfg:
   mypy:
     ignore_missing_imports:
       - serial
+      - soundfile
       - tensorflow
       - tflite_runtime
       - rich
@@ -35,14 +36,17 @@ setup_py:
   author_email: edge-info@appliedbrainresearch.com
   include_package_data: True
   install_req:
+    - click>=8.1.3
     - packaging>=20.9
     - pyserial>=3.5
     - rich>=13.3.1
+    - soundfile>=0.12.1
     - tensorflow>=2.10.0 # TODO: support earlier versions?
   tests_req:
     - mypy>=0.901
     - pytest>=7.1.1
     - pytest-rng>=1.0.0
+    - types-click>=7.1.0
   docs_req:
     - jupyter>=1.0.0
     - nbsphinx>=0.8.11
@@ -63,6 +67,9 @@ setup_py:
     - "Programming Language :: Python :: 3.10"
     - "Topic :: Scientific/Engineering"
     - "Topic :: Scientific/Engineering :: Artificial Intelligence"
+  entry_points:
+    console_scripts:
+      - nengo-edge=nengo_edge.cli:cli
 
 docs_conf_py:
   nengo_logo: nengo-edge-full-light.svg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Release history
 
 - Added warning when a downloaded nengo-edge model artifacts' version does not 
   match local environment nengo-edge version. (`#6`_)
+- Added ``nengo-edge package-dataset`` CLI command, which can be used to validate
+  and package KWS and ASR datasets. (`#10`_)
   
 **Changed**
 
@@ -35,6 +37,7 @@ Release history
 
 .. _#6: https://github.com/nengo/nengo-edge/pull/6
 .. _#8: https://github.com/nengo/nengo-edge/pull/8
+.. _#10: https://github.com/nengo/nengo-edge/pull/10
 
 23.7.30 (July 30, 2023)
 =======================

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,8 @@
 import json
+from typing import Any
 
 import pytest
+from click.testing import CliRunner
 
 from nengo_edge.version import version
 
@@ -32,3 +34,21 @@ def param_dir(tmp_path):
         json.dump(params, f)
 
     return tmp_path
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """
+    A version of ``click.testing.CliRunner`` that echoes output to stdout.
+
+    This is useful as it allows pytest to capture the output like normal (rather
+    than the CliRunner eating it all).
+    """
+
+    class EchoCliRunner(CliRunner):
+        def invoke(self, *args: Any, **kwargs: Any) -> Any:
+            result = super().invoke(*args, **kwargs)
+            print(result.stdout)
+            return result
+
+    return EchoCliRunner()

--- a/nengo_edge/__init__.py
+++ b/nengo_edge/__init__.py
@@ -1,5 +1,6 @@
 """Tools for working with NengoEdge."""
 
+from nengo_edge import validate
 from nengo_edge.device_modules.coral_device import CoralDeviceRunner
 from nengo_edge.micro_runner import DiscoRunner, NordicRunner
 from nengo_edge.network_runner import CoralRunner

--- a/nengo_edge/cli.py
+++ b/nengo_edge/cli.py
@@ -1,0 +1,77 @@
+"""Command-line interface for nengo-edge."""
+
+import tarfile
+from pathlib import Path
+from typing import Optional
+
+import click
+from rich import progress
+
+from nengo_edge import validate
+from nengo_edge.version import version
+
+
+@click.group()
+def cli() -> None:
+    """CLI for nengo-edge."""
+
+
+@cli.command()
+@click.argument(
+    "dataset_type",
+    type=click.Choice(["kws", "asr"], case_sensitive=False),
+)
+@click.argument(
+    "data_directory",
+    type=click.Path(exists=True, dir_okay=True),
+)
+@click.option(
+    "--validation-samples",
+    default=None,
+    type=int,
+    help=(
+        "Set the number of audio files to be validated before the dataset is packaged."
+    ),
+)
+def package_dataset(
+    dataset_type: str,
+    data_directory: str,
+    validation_samples: Optional[int],
+) -> None:
+    """
+    Validate and package a dataset for a given model type.
+
+    Parameters
+    ----------
+    dataset_type : str
+        One of kws or asr
+    data_directory : str
+        Directory containing a dataset split into train, validation and test
+        subdirectories.
+    validation_samples : Optional[int]
+        Maximum number of audio files to validate before packaging the dataset.
+    """
+    # use resolved data_directory to avoid "../" or symlinks
+    data_directory_path = Path(data_directory).resolve()
+    tar_fname = (
+        Path.cwd() / f"{dataset_type}-v{version}-{data_directory_path.name}.tar.gz"
+    )
+    # throw error if file already exists in cwd
+    if tar_fname.exists():
+        raise FileExistsError(f"{tar_fname} already exists.")
+
+    # get validated filepaths
+    file_paths = validate.validate_dataset(
+        dataset_type.lower(), data_directory_path, validation_samples
+    )
+
+    with tarfile.open(tar_fname, mode="w:gz") as f:
+        for path in progress.track(
+            file_paths,
+            description=f"Compressing dataset ({len(file_paths)} entries)",
+        ):
+            # use arcname to set filepath inside the archive to the
+            # relative path with respect to data_directory_path
+            f.add(str(path), arcname=str(path.relative_to(data_directory_path)))
+
+    print(f"Saved {dataset_type} dataset archive to {tar_fname}")

--- a/nengo_edge/tests/test_cli.py
+++ b/nengo_edge/tests/test_cli.py
@@ -1,0 +1,44 @@
+# pylint: disable=missing-docstring
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nengo_edge import cli
+from nengo_edge.tests.test_validate import mock_asr_dataset, mock_kws_dataset
+from nengo_edge.version import version
+
+
+@pytest.mark.parametrize("dataset_type", ("kws", "asr"))
+def test_package_dataset(
+    dataset_type: str,
+    tmp_path: Path,
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_directory = tmp_path / dataset_type
+    data_directory.mkdir()
+
+    if dataset_type == "kws":
+        mock_kws_dataset(data_directory)
+
+    elif dataset_type == "asr":
+        mock_asr_dataset(data_directory)
+
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(
+        cli.cli,
+        f"package-dataset {dataset_type} {data_directory}".split(),
+    )
+    assert result.exit_code == 0, result.exception
+
+    output_tar = Path.cwd() / f"{dataset_type}-v{version}-{data_directory.name}.tar.gz"
+    assert output_tar.exists()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        result = cli_runner.invoke(
+            cli.cli,
+            f"package-dataset {dataset_type} {data_directory}".split(),
+            catch_exceptions=False,
+        )

--- a/nengo_edge/tests/test_validate.py
+++ b/nengo_edge/tests/test_validate.py
@@ -1,0 +1,309 @@
+# pylint: disable=missing-docstring
+
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pytest
+import soundfile
+
+from nengo_edge import validate
+
+
+def save_audio_file(
+    filepath: Path,
+    audio_type: str,
+    sample_rate: int,
+    duration: float,
+) -> None:
+    # note: creating 2 channel data, second channel will be ignored
+    sample_data = np.random.uniform(
+        -32000, 32000, size=(int(sample_rate * duration), 2)
+    ).astype("int16")
+    soundfile.write(filepath, sample_data, sample_rate, format=audio_type)
+
+
+def save_transcript_file(
+    filepath: Path, fileIDs: List[str], sentences: List[str]
+) -> None:
+    with open(filepath, "w", encoding="utf-8") as f:
+        for fileID, sentence in zip(fileIDs, sentences):
+            f.write(f"{fileID} {sentence}\n")
+
+
+def mock_asr_dataset(
+    tmp_path: Path,
+    audio_type: str = "wav",
+    sample_rate: int = 16000,
+    duration: float = 0.5,  # in seconds
+    how_many: int = 10,
+) -> None:
+    rng = random.Random(0)
+    for split in ["train", "validation", "test"]:
+        split_dir = tmp_path / split
+        split_dir.mkdir()
+        fileIDs = []
+        sentences = []
+        for i in range(how_many):
+            fileIDs.append(f"some_audio_{i}.{audio_type}")
+            sentences.append(f"{''.join(rng.choices('abc ' , k=100))}")
+            save_audio_file(
+                split_dir / f"some_audio_{i}.{audio_type}",
+                audio_type=audio_type,
+                sample_rate=sample_rate,
+                duration=duration,
+            )
+        save_transcript_file(split_dir / "transcription.txt", fileIDs, sentences)
+
+
+def mock_kws_dataset(
+    tmp_path: Path,
+    audio_type: str = "wav",
+    sample_rate: int = 16000,
+    duration: float = 0.5,  # in seconds
+    keywords: Tuple[str, ...] = ("on", "off"),
+    how_many: int = 10,
+) -> None:
+    for split in ["train", "validation", "test"]:
+        split_dir = tmp_path / split
+        for word in keywords:
+            keyword_dir = split_dir / word
+            keyword_dir.mkdir(parents=True)
+            for i in range(how_many):
+                save_audio_file(
+                    keyword_dir / f"some_audio_{i}.{audio_type}",
+                    audio_type=audio_type,
+                    sample_rate=sample_rate,
+                    duration=duration,
+                )
+
+    background_dir = tmp_path / "background_noise"
+    background_dir.mkdir()
+    for i in range(2):
+        save_audio_file(
+            background_dir / f"some_audio_{i}.{audio_type}",
+            audio_type=audio_type,
+            sample_rate=sample_rate,
+            duration=duration,
+        )
+
+
+@pytest.mark.parametrize(
+    "split",
+    ("train", "validation", "test", "unknown"),
+)
+def test_infer_split(split: str) -> None:
+    path = Path(f"{split}/path/to/file.txt")
+    if split == "unknown":
+        with pytest.raises(ValueError, match=f"{path} should be"):
+            validate.infer_split(path)
+    else:
+        assert split == validate.infer_split(path)
+
+
+@pytest.mark.parametrize("audio_format", ("wav", "flac", "mp3"))
+def test_infer_audio_properties(audio_format: str, tmp_path: Path) -> None:
+    sample_rate = 16000
+    duration = 0.5
+    save_audio_file(
+        tmp_path / f"audio.{audio_format}",
+        audio_type=audio_format,
+        sample_rate=sample_rate,
+        duration=duration,
+    )
+
+    with open(tmp_path / f"audio.{audio_format}", "rb") as f:
+        audio_bytes = f.read()
+        audio_properties = validate.infer_audio_properties(audio_bytes)
+
+    assert audio_properties["sample_rate"] == sample_rate
+
+    # validate.infer_audio_properties returns clip duration in ms
+    assert audio_properties["clip_duration"] == duration * 1e3
+
+
+def test_validate_audio(tmp_path: Path) -> None:
+    sample_rate = 16000
+    duration = 0.5
+
+    # test clip duration warning
+    data_dir = tmp_path / "kws0"
+    data_dir.mkdir()
+    mock_kws_dataset(data_dir, sample_rate=sample_rate, duration=duration)
+    save_audio_file(
+        data_dir / "audio.wav",
+        audio_type="wav",
+        sample_rate=sample_rate,
+        duration=duration + 10,
+    )
+
+    audio_files = sorted(list(data_dir.rglob("*.wav")))
+    with pytest.warns(match="Clip durations"):
+        validate.validate_audio(audio_files)
+
+    # test sample rate error
+    data_dir = tmp_path / "kws1"
+    data_dir.mkdir()
+    mock_kws_dataset(data_dir, sample_rate=sample_rate, duration=duration)
+    save_audio_file(
+        data_dir / "audio.wav",
+        audio_type="wav",
+        sample_rate=sample_rate + 1,
+        duration=duration,
+    )
+
+    audio_files = list(data_dir.rglob("*.wav"))
+    with pytest.raises(ValueError, match="Found sample rates"):
+        validate.validate_audio(audio_files)
+
+
+def test_audio_map_fn(tmp_path: Path) -> None:
+    save_audio_file(
+        tmp_path / "audio.wav", audio_type="wav", sample_rate=16000, duration=1
+    )
+
+    props = validate.audio_map_fn(tmp_path / "audio.wav")
+    assert props["sample_rate"] == 16000
+    assert props["clip_duration"] == 1000
+
+
+def test_validate_transcriptions(tmp_path: Path) -> None:
+    data_dir = tmp_path / "asr0"
+    data_dir.mkdir()
+    mock_asr_dataset(data_dir)
+
+    with open(data_dir / "train" / "transcription.txt", "a+", encoding="utf-8") as f:
+        f.write("dummy_id.audio dummy sentence\n")
+
+    audio_files = list(data_dir.rglob("*.wav"))
+
+    with open(data_dir / "train" / "transcription.txt", "r", encoding="utf-8") as f:
+        transcription_lines = [
+            f"{data_dir / 'train'}/{line}" for line in f.read().splitlines()
+        ]
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=f"reference to {data_dir / 'train' / 'dummy_id.audio'}",
+    ):
+        validate.validate_transcriptions(transcription_lines, audio_files)
+
+
+def test_validate_kws_formatting(tmp_path: Path) -> None:
+    # test incompatible audio format
+    with pytest.raises(FileNotFoundError, match="Found no compatible audio"):
+        validate.validate_kws_formatting([])
+
+    # test missing split
+    fpaths = [
+        tmp_path / f"{split}" / "keyword" / "some_audio.wav"
+        for split in ("train", "validation")
+    ]
+    with pytest.raises(FileNotFoundError, match="Did not find train/"):
+        validate.validate_kws_formatting(fpaths)
+
+    # test warning when no background_noise dir present
+    fpaths = [
+        tmp_path / f"{split}" / "keyword" / "some_audio.wav"
+        for split in ("train", "validation", "test")
+    ]
+    with pytest.warns(match="No background_noise"):
+        validate.validate_kws_formatting(fpaths)
+
+    # test warning when extra top level directory is found with
+    # _dirname_ format
+    fpaths = [
+        tmp_path / f"{split}" / "keyword" / "some_audio.wav"
+        for split in ("train", "validation", "test", "_invalid_")
+    ]
+    with pytest.warns(match="Found directory _invalid_"):
+        validate.validate_kws_formatting(fpaths)
+
+    # test invalid/no keywords
+    fpaths = [
+        tmp_path / f"{split}" / "_invalid_" / "some_audio.wav"
+        for split in ("train", "validation", "test")
+    ]
+    with pytest.raises(FileNotFoundError, match="keyword directories"):
+        validate.validate_kws_formatting(fpaths)
+
+    # test keyword returns
+    fpaths = [
+        tmp_path / f"{split}" / f"keyword_{i}" / "some_audio.wav"
+        for i, split in enumerate(("train", "validation", "test"))
+    ]
+    props = validate.validate_kws_formatting(fpaths)
+    assert props["allKeywords"] == [f"keyword_{i}" for i in range(3)]
+
+
+def test_validate_asr_formatting(tmp_path: Path) -> None:
+    # test incompatible audio format
+    with pytest.raises(FileNotFoundError, match="Found no compatible audio"):
+        validate.validate_asr_formatting([], [tmp_path / "some.txt"])
+
+    with pytest.raises(FileNotFoundError, match="Found no compatible transcription"):
+        validate.validate_asr_formatting([tmp_path / "some_audio.wav"], [])
+
+    audio = [
+        tmp_path / f"{split}" / "some_audio.wav" for split in ("train", "validation")
+    ]
+    txt = [f.with_suffix(".txt") for f in audio]
+    # test missing split
+    with pytest.raises(FileNotFoundError, match="Did not find train/"):
+        validate.validate_asr_formatting(audio, txt)
+
+
+def test_validate_dataset_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # test empty directory error
+    with pytest.raises(FileNotFoundError, match="Found empty"):
+        validate.validate_dataset("kws", tmp_path, validation_samples=None)
+
+    # test really large dataset warning
+    def mock_kws_dataset_validation(audio_paths: List[Path]) -> Dict[str, List[str]]:
+        """fast kws validation."""
+        return {"allKeywords": []}
+
+    def mock_audio_validation(audio_paths: List[Path], dataset_type: str) -> None:
+        """fast audio validation."""
+
+    def rglob(*_: Any) -> List[Path]:
+        return [Path(f"audio_{i}.wav") for i in range(int(1e5 + 1))]
+
+    def is_file(*_: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        validate, "validate_kws_formatting", mock_kws_dataset_validation
+    )
+    monkeypatch.setattr(validate, "validate_audio", mock_audio_validation)
+    monkeypatch.setattr(Path, "rglob", rglob)
+    monkeypatch.setattr(Path, "is_file", is_file)
+
+    with pytest.warns(match=f"Validating {int(1e5) + 1} audio files"):
+        validate.validate_dataset("kws", tmp_path, validation_samples=None)
+
+
+@pytest.mark.parametrize("dataset_type", ("kws", "asr"))
+def test_validate_dataset(
+    dataset_type: str, tmp_path: Path, capfd: pytest.CaptureFixture
+) -> None:
+    data_dir = tmp_path / dataset_type
+    data_dir.mkdir()
+
+    if dataset_type == "kws":
+        mock_kws_dataset(data_dir)
+    else:
+        mock_asr_dataset(data_dir)
+
+    validated_fpaths = validate.validate_dataset(
+        dataset_type, data_dir, validation_samples=10
+    )
+
+    out = capfd.readouterr().out
+    assert "Successfully validated 10 audio files" in out
+    if dataset_type == "asr":
+        assert "Successfully validated 30 transcription entries" in out
+    assert validated_fpaths == [f for f in data_dir.rglob("*") if f.is_file()]

--- a/nengo_edge/validate.py
+++ b/nengo_edge/validate.py
@@ -1,0 +1,326 @@
+"""Various helper functions and tools for validating NengoEdge datasets."""
+
+import io
+import multiprocessing
+import os
+import random
+import warnings
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import soundfile
+from rich import progress
+
+
+def infer_split(relative_path: Path) -> str:
+    """
+    Infer the training split from a Path object.
+
+    The training split is inferred from the base part
+    of a file path, where the filepath should be a relative path,
+    with respect to its parent data directory. If the inferred split
+    is not one of train, validation or test, an error is thrown.
+
+    Parameters
+    ----------
+    relative_path : Path
+        File path, relative to its data directory.
+
+    Returns
+    -------
+    split : str
+        Returns one of train, validation or test.
+    """
+    for split in ["train", "validation", "test"]:
+        if relative_path.parts[0].startswith(split):
+            return split
+
+    # raise error if function does not return
+    raise ValueError(f"{relative_path} should be in one of train, validation or test")
+
+
+def infer_audio_properties(audio_bytes: bytes) -> Dict[str, Union[int, float]]:
+    """
+    Infer clip duration and sample rate from audio bytes.
+
+    Parameters
+    ----------
+    audio_bytes : bytes
+        Bytes like object containing audio to be read
+
+    Returns:
+    --------
+    props: Dict[str, Union[int, float]]
+        Dictionary containing the audio `sample_rate` as an int and
+        audio `clip_duration` as a float.
+    """
+    data, rate = soundfile.read(io.BytesIO(audio_bytes))
+    duration = len(data) / rate * 1e3  # in ms
+    props = {"clip_duration": duration, "sample_rate": int(rate)}
+    return props
+
+
+def audio_map_fn(file_path: Path) -> Dict[str, Union[int, float]]:
+    """Map function for multiprocessing audio files."""
+    return infer_audio_properties(file_path.read_bytes())
+
+
+def validate_audio(
+    audio_paths: List[Path], dataset_type: Optional[str] = "kws"
+) -> None:
+    """
+    Validate a portion of the audio files in the full dataset.
+
+    Validation will warn users if clip durations are inconsistent, as well as raise
+    an error if audio sample rates differ between clips in the dataset.
+
+    Parameters
+    ----------
+    audio_paths : List[Path]
+        A list of path objects pointing to audio files in the dataset.
+    dataset_type : str
+        One of `kws` or `asr`, to toggle relevant warnings/errors.
+    """
+    clip_durations = []
+    sample_rates = []
+
+    with progress.Progress() as p:
+        task_id = p.add_task(
+            f"Reading {len(audio_paths)} audio samples", total=len(audio_paths)
+        )
+        with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
+            for result in pool.imap_unordered(audio_map_fn, audio_paths):
+                clip_durations.append(result["clip_duration"])
+                sample_rates.append(result["sample_rate"])
+                p.advance(task_id)
+
+    if dataset_type == "kws" and clip_durations.count(clip_durations[0]) != len(
+        clip_durations
+    ):
+        # this isn't necessarily an error, clips will just be truncated/padded
+        # to the desired length
+        warnings.warn(
+            "Clip durations are inconsistent. They will be cropped "
+            "or padded at runtime."
+        )
+    if sample_rates.count(sample_rates[0]) != len(sample_rates):
+        raise ValueError(
+            f"Found sample rates in the range ({min(sample_rates)}, "
+            f"{max(sample_rates)}) Hz. Audio files require consistent sample "
+            "rates before uploading."
+        )
+
+    print(f"Successfully validated {len(audio_paths)} audio files.")
+
+
+def validate_transcriptions(
+    transcription_lines: List[str],
+    audio_paths: List[Path],
+) -> None:
+    """
+    Validate transcriptions for ASR datasets.
+
+    Each line in a transcription file should have the format:
+        `<filename>.<audio_format> <sentence>`
+    where the first column is the filename in the same directory
+    as the transcription file and the sentence portion is a space delimited
+    string of words corresponding to the audio file.
+
+    Validation will throw an error if transcription entries do not contain
+    filepaths that point to existing audio files in the dataset.
+
+    Parameters
+    ----------
+    transcription_lines : List[str]
+        A list of strings corresponding to the lines in each of the
+        transcription files, with each line prepended with the absolute file path
+        to the corresponding transcription file.
+    audio_paths : List[Path]
+        A list of path objects pointing to audio files in the dataset.
+    """
+    expected_set = set()
+    audio_set = set(audio_paths)
+    for line in progress.track(
+        transcription_lines,
+        description=f"Reading {len(transcription_lines)} transcription entries",
+    ):
+        expected_set.add(Path(line.split()[0]))
+
+    if not expected_set.issubset(audio_set):
+        missing = expected_set - audio_set
+        raise FileNotFoundError(
+            f"Found reference to {missing.pop()} in transcription, "
+            "but file does not exist."
+        )
+
+    print(f"Successfully validated {len(transcription_lines)} transcription entries.")
+
+
+def validate_kws_formatting(audio_paths: List[Path]) -> Dict[str, List[str]]:
+    """
+    Validate KWS datasets for proper directory structure and audio consistency.
+
+    Parameters
+    ----------
+    audio_paths : List[Path]
+        A list of path objects pointing to all audio files inside the data directory.
+
+    Returns
+    -------
+    dataset_properties : Dict[str, List[str]]
+        Dictionary containing a list of keywords that are inferred from
+        the dataset.
+    """
+
+    # check validation failure conditions
+    if len(audio_paths) == 0:
+        raise FileNotFoundError(
+            "Found no compatible audio files for kws datasets. "
+            "Ensure audio is one of mp3, wav or flac."
+        )
+
+    all_splits = set()
+    all_keywords = set()
+    common_path = os.path.commonpath(audio_paths)
+    for fpath in progress.track(
+        audio_paths, description="Validating dataset formatting"
+    ):
+        rel_path = fpath.relative_to(common_path) if len(common_path) > 1 else fpath
+        if rel_path.parts[0].startswith(("train", "validation", "test")):
+            all_splits.add(infer_split(rel_path))
+            if not rel_path.parts[1].startswith("_"):
+                all_keywords.add(rel_path.parts[1])
+        else:
+            all_splits.add(rel_path.parts[0])
+
+    # check split conditions are met
+    if not set(("test", "train", "validation")).issubset(all_splits):
+        raise FileNotFoundError("Did not find train/validation/test folders in dataset")
+
+    # make sure there are directories in the dataset archive with
+    # names corresponding to viable keywords
+    if len(all_keywords) == 0:
+        raise FileNotFoundError("Did not find any keyword directories.")
+
+    # warn if no background noise directory
+    if "background_noise" not in all_splits:
+        warnings.warn(
+            "No background_noise directory found. "
+            "Consider adding for optimal kws performance in NengoEdge."
+        )
+
+    # warn about unused directories
+    for split in all_splits:
+        if split not in ["train", "validation", "test", "background_noise"]:
+            warnings.warn(
+                f"Found directory {split}, which will be unused by NengoEdge."
+            )
+
+    dataset_properties = {"allKeywords": sorted(list(all_keywords))}
+    return dataset_properties
+
+
+def validate_asr_formatting(
+    audio_paths: List[Path], transcription_paths: List[Path]
+) -> None:
+    """
+    Validate ASR datasets for proper directory structure, audio consistency, and
+    transcription formatting.
+
+    Parameters
+    ----------
+    audio_paths : List[Path]
+        A list of path objects pointing to all audio
+        files inside the data directory.
+    transcription_paths : List[Path]
+        A list of path objects pointing to all transcription
+        files inside the data directory.
+    """
+
+    if len(audio_paths) == 0:
+        raise FileNotFoundError(
+            "Found no compatible audio files for asr datasets. "
+            "Ensure audio is one of mp3, wav or flac."
+        )
+
+    if len(transcription_paths) == 0:
+        raise FileNotFoundError(
+            "Found no compatible transcription files for asr datasets. "
+            "Ensure transcriptions are saved in txt files."
+        )
+
+    all_splits = set()
+    file_paths = audio_paths + transcription_paths
+    common_path = os.path.commonpath(file_paths)
+    for fpath in progress.track(
+        file_paths, description="Validating dataset formatting"
+    ):
+        all_splits.add(
+            infer_split(
+                fpath.relative_to(common_path) if len(common_path) > 1 else fpath
+            )
+        )
+
+    # check split conditions are met
+    for split in ["train", "validation", "test"]:
+        if split not in all_splits:
+            raise FileNotFoundError(
+                "Did not find train/validation/test folders in dataset"
+            )
+
+
+def validate_dataset(
+    dataset_type: str, data_directory: Path, validation_samples: Optional[int]
+) -> List[Path]:
+    """
+    Validate a dataset based on a given type and directory for that dataset.
+
+    Parameters
+    ----------
+    dataset_type : str
+        Type of dataset. One of kws or asr.
+    data_directory : Path
+        The directory in which the dataset resides.
+    validation_samples : Optional[int]
+        Maximum number of audio files to validate before packaging the dataset.
+    """
+    # ensure we are only inspecting file paths, not directories
+    file_paths = [fpath for fpath in data_directory.rglob("*") if fpath.is_file()]
+
+    if len(file_paths) == 0:
+        raise FileNotFoundError(f"Found empty directory {data_directory}")
+
+    audio_paths = [f for f in file_paths if f.suffix in [".mp3", ".wav", ".flac"]]
+    if validation_samples is None:
+        validation_samples = len(audio_paths)
+        if len(audio_paths) > 1e5:
+            warnings.warn(
+                f"Validating {len(audio_paths)} audio files may take many hours. "
+                f"Run with --validation-steps 100000 to choose a random subset."
+            )
+
+    assert isinstance(validation_samples, int)
+    audio_subset = random.sample(audio_paths, validation_samples)
+
+    if dataset_type == "kws":
+        # validate formatting over all paths
+        validate_kws_formatting(audio_paths)
+
+        # validate audio over subset if necessary
+        validate_audio(audio_subset, dataset_type="kws")
+
+    elif dataset_type == "asr":
+        txt_paths = [f for f in file_paths if f.suffix in [".txt"]]
+        validate_asr_formatting(audio_paths, txt_paths)
+        validate_audio(audio_subset, dataset_type="asr")
+
+        # add absolute file path to transcription entries in order
+        # to search for corresponding audio files
+        transcription_lines = [
+            f"{f.parent}/{line}"
+            for f in txt_paths
+            for line in f.read_text().splitlines()
+        ]
+        validate_transcriptions(transcription_lines, audio_paths)
+
+    return file_paths

--- a/nengo_edge/version.py
+++ b/nengo_edge/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 8, 29)  # bones: ignore
+version_info = (23, 9, 11)  # bones: ignore
 
 name = "nengo-edge"
 dev = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,8 @@ plugins = numpy.typing.mypy_plugin
 
 [mypy-serial.*]
 ignore_missing_imports = True
+[mypy-soundfile.*]
+ignore_missing_imports = True
 [mypy-tensorflow.*]
 ignore_missing_imports = True
 [mypy-tflite_runtime.*]

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,11 @@ root = pathlib.Path(__file__).parent
 version = runpy.run_path(str(root / "nengo_edge" / "version.py"))["version"]
 
 install_req = [
+    "click>=8.1.3",
     "packaging>=20.9",
     "pyserial>=3.5",
     "rich>=13.3.1",
+    "soundfile>=0.12.1",
     "tensorflow>=2.10.0",
 ]
 docs_req = [
@@ -48,6 +50,7 @@ tests_req = [
     "mypy>=0.901",
     "pytest>=7.1.1",
     "pytest-rng>=1.0.0",
+    "types-click>=7.1.0",
 ]
 
 setup(
@@ -84,4 +87,9 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
+    entry_points={
+        "console_scripts": [
+            "nengo-edge=nengo_edge.cli:cli",
+        ],
+    },
 )


### PR DESCRIPTION
PR introduces a first iteration of a `nengo-edge` CLI called `nengo-edge-tools`. In this PR the only command that's supported is `nengo-edge-tools package-dataset`, which validates and compresses a dataset given the intended downstream model type. 

Some of the logic for validating datasets is intended to be reused by the `nengo-edge-server` code for validating dataset uploads. 