### PR TITLE
Support nlp inference and on-device tokenization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,6 @@ jobs:
           path: nengo-edge
       - uses: actions/checkout@v3
         with:
-          repository: nengo/state-space
-          path: state-space
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/checkout@v3
-        with:
           repository: nengo/tsp-ops
           path: tsp-ops
           token: ${{ secrets.GH_TOKEN }}
@@ -114,7 +109,6 @@ jobs:
           micromamba install sentencepiece
       - name: Install NengoEdge libraries
         run: |
-          pip install ../state-space
           pip install ../tsp-ops
           pip install ../nengo-edge-models
           pip install ../nengo-edge-hw

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,11 @@ Release history
   ``FastSentencepieceTokenizer`` to ensure compatibility with the core sentencepiece 
   library. (`#17`_)
 
+**Fixed**
+
+- Fixed model output decoding for ASR. ``SavedModelRunner`` now removes blank
+  tokens and merges repeating tokens before detokenization. (`#17`_)
+
 .. _#9: https://github.com/nengo/nengo-edge/pull/9
 .. _#17: https://github.com/nengo/nengo-edge/pull/17
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Release history
   FAQ section). (`#9`_)
 - Added support for input string processing and NLP model inference in 
   ``SavedModelRunner``. (`#17`_)
+- Added ``NetworkTokenizer`` class to perform remote calls to a device
+  CLI that supports sentencepiece tokenization. (`#17`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,8 +26,17 @@ Release history
 
 - Updated documentation with new content (additional tutorials, CLI documentation,
   FAQ section). (`#9`_)
+- Added support for input string processing and NLP model inference in 
+  ``SavedModelRunner``. (`#17`_)
+
+**Changed**
+
+- ``SavedModelRunner`` tokenizer now uses ``SentencepieceTokenizer`` instead of
+  ``FastSentencepieceTokenizer`` to ensure compatibility with the core sentencepiece 
+  library. (`#17`_)
 
 .. _#9: https://github.com/nengo/nengo-edge/pull/9
+.. _#17: https://github.com/nengo/nengo-edge/pull/17
 
 23.9.27 (September 27, 2023)
 ============================
@@ -54,6 +63,8 @@ Release history
 .. _#10: https://github.com/nengo/nengo-edge/pull/10
 .. _#13: https://github.com/nengo/nengo-edge/pull/13
 .. _#15: https://github.com/nengo/nengo-edge/pull/15
+.. _#17: https://github.com/nengo/nengo-edge/pull/17
+
 
 23.7.30 (July 30, 2023)
 =======================

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoEdge Tools license
 ***********************
 
-Copyright (c) 2022-2023 Applied Brain Research
+Copyright (c) 2022-2024 Applied Brain Research
 
 **MIT License**
 

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,7 @@ def param_dir(tmp_path):
             "state_shapes": [10, 10],
             "return_sequences": True,
             "n_unroll": 1,
+            "type": "kws",
         },
         "postprocessing": {
             "vocab_size": 20,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ user_agent = "nengo_edge"
 
 project = "NengoEdge Tools"
 authors = "Applied Brain Research"
-copyright = "2022-2023 Applied Brain Research"
+copyright = "2022-2024 Applied Brain Research"
 version = ".".join(nengo_edge.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_edge.__version__  # Full version, with tags
 

--- a/nengo_edge/device_modules/network_tokenizer.py
+++ b/nengo_edge/device_modules/network_tokenizer.py
@@ -1,0 +1,153 @@
+"""Interface for running an exported SentencePiece tokenizer on network accessible
+devices."""
+
+import subprocess
+from pathlib import Path
+from typing import List, Union
+
+import numpy as np
+
+from nengo_edge.network_runner import NetworkRunner
+
+
+class NetworkTokenizer(NetworkRunner):
+    """
+    Class to access a SentencePiece command line interface installed on a network
+    accessible device.
+
+    Can be used to tokenize and detokenize values for asr and nlp inference.
+    """
+
+    def __init__(self, directory: Union[str, Path], username: str, hostname: str):
+        super().__init__(
+            directory=directory, device_runner="", username=username, hostname=hostname
+        )
+
+        if self.model_params["type"] not in ["asr", "nlp"]:
+            raise ValueError("Tokenizers are only supported for ASR and NLP models.")
+
+        self.tokenizer_file = None
+        for params in [self.preprocessing, self.postprocessing]:
+            if "tokenizer_file" in params:
+                self.tokenizer_file = params["tokenizer_file"]
+
+        if self.tokenizer_file is None:
+            raise ValueError(
+                f"Cannot find entry for tokenizer_file in "
+                f"{self.directory}/parameters.json."
+            )
+
+        self.remote_dir = Path("/tmp/nengo-edge-tokenizer")
+
+    def prepare_device_runner(self) -> None:  # pragma: no cover (needs device)
+        """Send required runtime parameters/modules before any inputs."""
+        assert (
+            len(self.remote_dir.parts) > 2 and self.remote_dir.parts[1] == "tmp"
+        ), f"remote_dir ({self.remote_dir}) not in /tmp"
+
+        subprocess.run(
+            f"ssh {self.address} rm -rf {self.remote_dir}".split(), check=True
+        )
+        subprocess.run(
+            f"ssh {self.address} mkdir -p {self.remote_dir}".split(), check=True
+        )
+
+        # copy files to remote
+        assert self.tokenizer_file is not None
+        self._scp([self.directory / self.tokenizer_file])
+        self.prepared = True
+
+    def tokenize(self, input_text: str) -> List[int]:  # pragma: no cover (needs device)
+        """
+        Map strings to their corresponding integer tokens.
+
+        This function utilizes an ssh command to access the SentencePiece command
+        line interface on the configured network device.
+
+        Parameters
+        ----------
+        input_text: str
+            Input string to be tokenized.
+
+        Returns
+        -------
+        token_ids: List[int]
+            A list of integers of length ``(n_tokens)``.
+        """
+        assert self.tokenizer_file is not None
+        cmd = (
+            f"ssh {self.address} spm_encode"
+            f" --model={self.remote_dir / self.tokenizer_file}"
+            f" --output_format=id"
+        )
+        output = subprocess.run(
+            cmd.split(),
+            input=input_text,
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        )
+        token_string = output.stdout.rstrip()
+        token_ids = [int(token) for token in token_string.split()]
+        return token_ids
+
+    def detokenize(self, inputs: np.ndarray) -> str:  # pragma: no cover (needs device)
+        """
+        Map integer tokens to their corresponding string token.
+
+        This function utilizes an ssh command to access the SentencePiece command
+        line interface on the configured network device.
+
+        Parameters
+        ----------
+        inputs: np.ndarray
+            Input array containing integer values. Array should be generated
+            from a top-1 decoding strategy (e.g. greedy decoding)
+            on asr model outputs and have a size of ``(batch_size, output_steps)``.
+
+        Returns
+        -------
+        decoded_text: str
+            A string generated from the decoded input integers.
+        """
+
+        token_string = " ".join([str(token) for token in inputs[inputs != -1]])
+
+        assert self.tokenizer_file is not None
+        cmd = (
+            f"ssh {self.address} spm_decode"
+            f" --model={self.remote_dir / self.tokenizer_file}"
+            f" --input_format=id"
+        )
+        output = subprocess.run(
+            cmd.split(),
+            input=token_string,
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        )
+        decoded_text = output.stdout.rstrip()
+        return decoded_text
+
+    def run(self, inputs: Union[np.ndarray, List[str]]) -> np.ndarray:
+        """Run the main tokenizer logic on the given inputs."""
+        if not self.prepared:
+            self.prepare_device_runner()
+
+        if isinstance(inputs[0], str):
+            outputs = np.asarray([self.tokenize(text) for text in inputs], dtype=object)
+        else:
+            assert isinstance(inputs, np.ndarray)
+
+            if inputs.dtype not in ["int32", "int64"]:
+                raise ValueError(f"{inputs.dtype=} must be one of int32/int64.")
+
+            if inputs.ndim != 2:
+                raise ValueError(
+                    f"inputs must have exactly 2 dimensions, found {inputs.ndim}."
+                )
+
+            outputs = np.asarray(
+                [self.detokenize(tokens) for tokens in inputs], dtype=np.str_
+            )
+        return outputs

--- a/nengo_edge/device_modules/tests/test_network_tokenizer.py
+++ b/nengo_edge/device_modules/tests/test_network_tokenizer.py
@@ -1,0 +1,140 @@
+# pylint: disable=missing-docstring
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from string import ascii_lowercase
+from typing import Any, Dict, List
+
+import numpy as np
+import pytest
+from tensorflow_text import SentencepieceTokenizer
+
+from nengo_edge.device_modules.network_tokenizer import NetworkTokenizer
+from nengo_edge.tests.test_saved_model_runner import new_tokenizer
+from nengo_edge.version import version
+
+
+@pytest.fixture(scope="module", name="model_path")
+def fixture_model_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_path = tmp_path_factory.mktemp("sentencepiece")
+    _, tokenizer_path = new_tokenizer(tmp_path)
+    return tokenizer_path
+
+
+def prepare_tokenizer(
+    temp_dir: Path,
+    sp_model_path: Path,
+    layer: str = "preprocessing",
+    model_type: str = "asr",
+) -> None:
+    params: Dict[str, Dict[str, Any]] = {
+        "preprocessing": {},
+        "model": {
+            "return_sequences": True,
+            "type": model_type,
+        },
+        "postprocessing": {},
+        "version": {"nengo-edge": version},
+    }
+    if layer in params:
+        params[layer]["tokenizer_file"] = sp_model_path.name
+
+    with open(temp_dir / "parameters.json", "w", encoding="utf-8") as f:
+        json.dump(params, f)
+
+    shutil.copy(sp_model_path, temp_dir / sp_model_path.name)
+
+
+class MockTokenizer(NetworkTokenizer):
+    def _scp(self, files_to_copy: List[Path]) -> None:
+        subprocess.run(
+            f"cp -r {' '.join(str(p) for p in files_to_copy)} "
+            f"{self.remote_dir}".split(),
+            check=True,
+        )
+
+    def check_connection(self) -> None:
+        pass
+
+    def prepare_device_runner(self) -> None:
+        # this is the same as the super implementation, but with the ssh mkdir replaced
+        # with a local mkdir
+        # subprocess.run(
+        #     f"ssh {self.address} mkdir -p {self.remote_dir}".split(), check=True
+        # )
+        assert self.tokenizer_file is not None
+        self.remote_dir.mkdir(exist_ok=True, parents=True)
+        self._scp([self.directory / self.tokenizer_file])
+        self.prepared = True
+
+        self.sp = SentencepieceTokenizer(
+            (self.remote_dir / self.tokenizer_file).read_bytes()
+        )
+
+    def tokenize(self, input_text: str) -> List[int]:
+        tokens = self.sp.tokenize(input_text).numpy()
+        return tokens
+
+    def detokenize(self, inputs: np.ndarray) -> str:
+        decoded_text = self.sp.detokenize(inputs[inputs != -1]).numpy().decode()
+        return decoded_text
+
+
+@pytest.mark.parametrize("layer", ("preprocessing", "postprocessing"))
+def test_paths(layer: str, model_path: Path, tmp_path: Path) -> None:
+    prepare_tokenizer(tmp_path, sp_model_path=model_path, model_type="asr", layer=layer)
+    network_tokenizer = MockTokenizer(tmp_path, "name", "host")
+    network_tokenizer.prepare_device_runner()
+    assert network_tokenizer.tokenizer_file is not None
+    assert network_tokenizer.tokenizer_file == model_path.name
+    assert (network_tokenizer.remote_dir / model_path.name).exists()
+
+
+def test_errors(rng: np.random.RandomState, model_path: Path, tmp_path: Path) -> None:
+    # test wrong model type error
+    prepare_tokenizer(tmp_path, sp_model_path=model_path, model_type="kws")
+    with pytest.raises(ValueError, match="only supported for ASR and NLP models"):
+        MockTokenizer(tmp_path, "name", "host")
+
+    # test error with missing tokenizer_file entry in the parameter file
+    prepare_tokenizer(tmp_path, sp_model_path=model_path, layer="no layer")
+    with pytest.raises(ValueError, match="Cannot find entry for tokenizer_file"):
+        MockTokenizer(tmp_path, "name", "host")
+
+    # test wrong input type on detokenization
+    prepare_tokenizer(tmp_path, sp_model_path=model_path)
+    network_tokenizer = MockTokenizer(tmp_path, "name", "host")
+    with pytest.raises(ValueError, match="must be one of int32/int64"):
+        network_tokenizer.run(rng.randint(0, 255, (32, 50)).astype("float32"))
+
+    # test wrong number of dimension on input
+    with pytest.raises(ValueError, match="inputs must have exactly 2 dimensions"):
+        network_tokenizer.run(rng.randint(0, 255, (32,)).astype("int32"))
+
+
+def test_tokenize_detokenize(
+    rng: np.random.RandomState, param_dir: Path, model_path: Path, tmp_path: Path
+) -> None:
+    prepare_tokenizer(tmp_path, sp_model_path=model_path)
+    network_tokenizer = MockTokenizer(tmp_path, "name", "host")
+
+    input_text = [
+        " ".join(
+            "".join(rng.choice([*ascii_lowercase], size=3))  # type: ignore
+            for _ in range(10)
+        )
+        for i in range(32)
+    ]
+    token_ids = network_tokenizer.run(input_text)
+    max_len = np.max([t.shape[0] for t in token_ids])
+    token_ids = np.array(
+        [
+            np.concatenate([t, np.full(max_len - t.shape[0], -1, dtype="int32")])
+            for t in token_ids
+        ]
+    )
+    decoded_text = network_tokenizer.run(token_ids)
+
+    assert all(t == t_decoded for t, t_decoded in zip(input_text, decoded_text))

--- a/nengo_edge/network_runner.py
+++ b/nengo_edge/network_runner.py
@@ -39,7 +39,9 @@ class NetworkRunner:
     ):
         self.directory = Path(directory)
         self.device_runner = Path(device_runner)
-        self.model_params, self.preprocessing = config.load_params(self.directory)[:2]
+        self.model_params, self.preprocessing, self.postprocessing = config.load_params(
+            self.directory
+        )
         self.return_sequences = self.model_params["return_sequences"]
 
         self.username = username
@@ -91,7 +93,13 @@ class NetworkRunner:
 
     def prepare_device_runner(self) -> None:  # pragma: no cover (needs device)
         """Send required runtime parameters/modules before any inputs."""
+        assert (
+            len(self.remote_dir.parts) > 2 and self.remote_dir.parts[1] == "tmp"
+        ), f"remote_dir ({self.remote_dir}) not in /tmp"
 
+        subprocess.run(
+            f"ssh {self.address} rm -rf {self.remote_dir}".split(), check=True
+        )
         subprocess.run(
             f"ssh {self.address} mkdir -p {self.remote_dir}".split(), check=True
         )

--- a/nengo_edge/saved_model_runner.py
+++ b/nengo_edge/saved_model_runner.py
@@ -2,7 +2,7 @@
 
 import warnings
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 
@@ -10,9 +10,10 @@ from nengo_edge import config
 
 try:
     import tensorflow as tf
-    from tensorflow_text import FastSentencepieceTokenizer
+    from tensorflow_text import SentencepieceTokenizer
 
     from nengo_edge import ragged  # pylint: disable=ungrouped-imports
+
 except ImportError:  # pragma: no cover
     warnings.warn("TensorFlow is not installed; cannot use SavedModelRunner.")
 
@@ -30,20 +31,18 @@ class SavedModelRunner:
         )
 
         if self.model_params["type"] == "asr":
-            if (
-                "tokenizer_file" in self.postprocessing
-                and (self.directory / self.postprocessing["tokenizer_file"]).exists()
-            ):
-                self.tokenizer = FastSentencepieceTokenizer(
-                    (
-                        self.directory / self.postprocessing["tokenizer_file"]
-                    ).read_bytes()
-                )
-            else:
-                self.tokenizer = None
+            self.tokenizer = self.get_tokenizer(self.postprocessing)
+            if self.tokenizer is None:
                 warnings.warn(
                     "No tokenizer model found, cannot decode ASR outputs. "
                     "Consider re-downloading ASR run artifacts."
+                )
+        elif self.model_params["type"] == "nlp":
+            self.tokenizer = self.get_tokenizer(self.preprocessing)
+            if self.tokenizer is None:
+                raise ValueError(
+                    "No tokenizer model found and is required to process string inputs."
+                    "Please re-download the NLP artifacts."
                 )
 
         self.reset_state()
@@ -52,6 +51,34 @@ class SavedModelRunner:
         """Reset the internal state of the model to initial conditions."""
 
         self.state: Optional[List[tf.Tensor]] = None
+
+    def get_tokenizer(
+        self, params: Dict[str, str]
+    ) -> Optional["SentencepieceTokenizer"]:
+        """
+        Load a ``tensorflow_text.SentencepieceTokenizer``.
+
+        Returns None if no ``tokenizer_file`` exists in the load directory.
+
+        Parameters
+        ----------
+        params: Dict[str, str]
+            Configuration dictionary containing the name of the
+            ``tokenizer_file`` found in the save directory.
+
+        Returns
+        -------
+        tokenizer: ``tensorflow_text.SentencepieceTokenizer``
+            A sentencepiece tokenizer with a trained vocabulary.
+        """
+        if (
+            "tokenizer_file" in params
+            and (self.directory / params["tokenizer_file"]).exists()
+        ):
+            return SentencepieceTokenizer(
+                (self.directory / params["tokenizer_file"]).read_bytes()
+            )
+        return None
 
     def _run_model(self, inputs: np.ndarray) -> np.ndarray:
         """
@@ -98,27 +125,40 @@ class SavedModelRunner:
 
         return outputs[0].numpy()
 
-    def run(self, inputs: np.ndarray) -> np.ndarray:
+    def run(self, inputs: Union[np.ndarray, List[str]]) -> np.ndarray:
         """
         Run the model on the given inputs.
 
-        Also applies model type specific actions to outputs. For example,
-        ASR model outputs are automatically detokenized to construct
-        a string prediction.
+        This function applies model specific actions to inputs or outputs.
+        For example, ASR model outputs are automatically detokenized to construct
+        a string prediction. For NLP models, the list of strings is
+        automatically processed into integer tokens from a saved
+        vocabulary.
 
         Parameters
         ----------
-        inputs : np.ndarray
-            Model input values (should have shape ``(batch_size, input_steps)``).
+        inputs : Union[np.ndarray, List[str]]
+            For audio based models, such as KWS and ASR, model input values
+            should be stored in a numpy array with a shape of
+            ``(batch_size, input_steps)``.
+            For text based NLP models, input strings should be stored in a list with
+            a length equal to ``batch_size``.
 
         Returns
         -------
         outputs : np.ndarray
             Model output values with shape ``(batch_size, output_steps, output_d)``
-            for KWS and ``(batch_size)`` for ASR.
+            for KWS, ``(batch_size)`` for ASR and ``(batch_size, output_d)`` for NLP.
         """
 
-        if inputs.dtype == object and self.model_params["type"] == "kws":
+        if isinstance(inputs[0], str):
+            # Process string inputs
+            assert self.model_params["type"] == "nlp"
+            assert self.tokenizer is not None
+            inputs = self.tokenizer.tokenize([s.lower() for s in inputs]).numpy()
+
+        assert isinstance(inputs, np.ndarray)
+        if self.model_params["type"] == "kws" and inputs.dtype == object:
             raise NotImplementedError("KWS models do not support ragged inputs")
 
         outputs = self._run_model(inputs)

--- a/nengo_edge/tests/test_saved_model_runner.py
+++ b/nengo_edge/tests/test_saved_model_runner.py
@@ -1,19 +1,23 @@
 # pylint: disable=missing-docstring
 
+import json
 from pathlib import Path
-from typing import Literal
+from string import ascii_lowercase
+from typing import Any, Dict, Literal
 
 import numpy as np
 import pytest
 import tensorflow as tf
 from nengo_edge_hw import gpu
-from nengo_edge_models.asr.layers import Tokenizer
 from nengo_edge_models.asr.metrics import decode_predictions
 from nengo_edge_models.asr.models import lmuformer_tiny
 from nengo_edge_models.kws.models import lmu_small
+from nengo_edge_models.layers import Tokenizer
 from nengo_edge_models.models import MFCC
+from nengo_edge_models.models import Tokenizer as TokenizerDesc
+from nengo_edge_models.nlp.models import LMUformerEncoderNLP, lmuformer_small_sim
 
-from nengo_edge import ragged
+from nengo_edge import ragged, version
 from nengo_edge.saved_model_runner import SavedModelRunner
 
 
@@ -49,67 +53,91 @@ def test_runner(
 
 
 @pytest.mark.parametrize("mode", ("model-only", "feature-only", "full"))
+@pytest.mark.parametrize("model_type", ("asr", "nlp"))
 def test_runner_ragged(
-    mode: str, rng: np.random.RandomState, seed: int, tmp_path: Path
+    mode: str, model_type: str, rng: np.random.RandomState, seed: int, tmp_path: Path
 ) -> None:
     tf.keras.utils.set_random_seed(seed)
 
-    pipeline = lmuformer_tiny()
+    pipeline = lmuformer_tiny() if model_type == "asr" else lmuformer_small_sim()
+    tokenizer = Tokenizer(
+        vocab_size=256,
+        corpus=Path(__file__).read_text(encoding="utf-8").splitlines(),
+    )
+    (tmp_path / "tokenizer").mkdir(parents=True, exist_ok=True)
+    tokenizer_path = tokenizer.save(tmp_path / "tokenizer")
+
+    if model_type == "asr":
+        assert isinstance(pipeline.post[0], TokenizerDesc)
+        pipeline.post[0].tokenizer_file = tokenizer_path
+    else:
+        assert isinstance(pipeline.pre[0], TokenizerDesc)
+        assert isinstance(pipeline.model[1], LMUformerEncoderNLP)
+        pipeline.pre[0].tokenizer_file = tokenizer_path
+        pipeline.pre[0].vocab_size = 256
+        pipeline.model[1].vocab_size = 256
+
     if mode == "feature-only":
         pipeline.model = []
         pipeline.post = []
 
     elif mode == "model-only":
-        pipeline.pre = []
+        if model_type == "asr":
+            pipeline.pre = []
         pipeline.post = []
 
-    elif mode == "full":
-        tokenizer = Tokenizer(
-            vocab_size=256,
-            corpus=Path(__file__).read_text(encoding="utf-8").splitlines(),
-        )
-        (tmp_path / "tokenizer").mkdir(parents=True, exist_ok=True)
-        tokenizer_path = tokenizer.save(tmp_path / "tokenizer")
-        pipeline.post[0].tokenizer_file = tokenizer_path
-
     interface = gpu.host.Interface(pipeline, build_dir=tmp_path, return_sequences=True)
-
-    inputs = rng.uniform(
-        -1, 1, size=(32,) + ((49, 80) if mode == "model-only" else (16000,))
-    ).astype("float32")
-
     interface.export_model(tmp_path)
     runner = SavedModelRunner(tmp_path)
+    if model_type == "asr":
+        inputs = rng.uniform(
+            -1, 1, size=(32,) + ((49, 80) if mode == "model-only" else (16000,))
+        ).astype("float32")
 
-    inputs = np.array(
-        [
-            inputs[0, : int(inputs.shape[1] * 0.5)],
-            inputs[1, : int(inputs.shape[1] * 0.8)],
-        ],
-        dtype=object,
-    )
-    ragged_out = runner.run(inputs)
-    ragged_out0 = runner.run(inputs[0][None, ...])
-    ragged_out1 = runner.run(inputs[1][None, ...])
-
-    if mode != "full":
-        # test numerical output case
-        assert (1,) + ragged_out[0].shape == ragged_out0.shape
-        assert (1,) + ragged_out[1].shape == ragged_out1.shape
-        # note: increased tolerances here due to the conformer padding error that will
-        # be fixed when we switch to an LMU-based implementation
-        assert np.allclose(ragged_out[0][None, ...], ragged_out0, atol=2e-3), np.max(
-            abs(ragged_out[0] - ragged_out0)
+        inputs = np.array(
+            [
+                inputs[0, : int(inputs.shape[1] * 0.5)],
+                inputs[1, : int(inputs.shape[1] * 0.8)],
+            ],
+            dtype=object,
         )
-        assert np.allclose(ragged_out[1][None, ...], ragged_out1, atol=2e-3), np.max(
-            abs(ragged_out[1] - ragged_out1)
-        )
+        ragged_in0 = inputs[0:1]
+        ragged_in1 = inputs[1:2]
     else:
+        inputs = np.asarray(
+            [
+                " ".join(
+                    "".join(rng.choice([*ascii_lowercase], size=3))
+                    for _ in range(10 + i * 10)
+                )
+                for i in range(2)
+            ]
+        )
+
+        ragged_in0 = inputs[[0]]
+        ragged_in1 = inputs[[1]]
+
+    ragged_out = runner.run(inputs)
+    ragged_out0 = runner.run(ragged_in0)
+    ragged_out1 = runner.run(ragged_in1)
+
+    if mode == "full" and model_type == "asr":
         # test string output case
         assert len(ragged_out[0]) == len(ragged_out0[0])
         assert len(ragged_out[1]) == len(ragged_out1[0])
         assert ragged_out[0] == ragged_out0[0]
         assert ragged_out[1] == ragged_out1[0]
+    else:
+        # test numerical output case
+        assert (1,) + ragged_out[0].shape == ragged_out0.shape
+        assert (1,) + ragged_out[1].shape == ragged_out1.shape
+
+        assert np.allclose(ragged_out[0][None, ...], ragged_out0, atol=2e-6), np.max(
+            abs(ragged_out[0] - ragged_out0)
+        )
+        assert np.allclose(ragged_out[1][None, ...], ragged_out1, atol=2e-6), np.max(
+            abs(ragged_out[1] - ragged_out1)
+        )
 
 
 def test_asr_detokenization(
@@ -132,13 +160,53 @@ def test_asr_detokenization(
     interface = gpu.host.Interface(pipeline, build_dir=tmp_path, return_sequences=True)
     interface.export_model(tmp_path)
 
-    monkeypatch.setattr(SavedModelRunner, "_run_model", lambda s, x: x)  # type: ignore
+    monkeypatch.setattr(SavedModelRunner, "_run_model", lambda s, x: x)
     runner = SavedModelRunner(tmp_path)
 
     inputs = rng.uniform(0, 1, (32, 10, 257))
     outputs = runner.run(inputs)
     gt = decode_predictions(ragged.to_masked(inputs), tokenizer)
     assert np.all(outputs == gt)
+
+
+def test_nlp_tokenization(
+    rng: np.random.RandomState,
+    seed: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tf.keras.utils.set_random_seed(seed)
+
+    pipeline = lmuformer_small_sim()
+    tokenizer = Tokenizer(
+        vocab_size=256,
+        corpus=Path(__file__).read_text(encoding="utf-8").splitlines(),
+    )
+    (tmp_path / "tokenizer").mkdir(parents=True, exist_ok=True)
+    tokenizer_path = tokenizer.save(tmp_path / "tokenizer")
+
+    assert isinstance(pipeline.pre[0], TokenizerDesc)
+    assert isinstance(pipeline.model[1], LMUformerEncoderNLP)
+    pipeline.pre[0].tokenizer_file = tokenizer_path
+    pipeline.pre[0].vocab_size = 256
+    pipeline.model[1].vocab_size = 256
+
+    interface = gpu.host.Interface(pipeline, build_dir=tmp_path)
+    interface.export_model(tmp_path)
+
+    monkeypatch.setattr(SavedModelRunner, "_run_model", lambda s, x: x)
+    runner = SavedModelRunner(tmp_path)
+
+    text_batch = [
+        " ".join("".join(rng.choice([*ascii_lowercase], size=3)) for _ in range(10))
+        for _ in range(32)
+    ]
+
+    outputs = runner.run(text_batch)
+    gt = tokenizer.tokenize(text_batch).numpy()  # type: ignore
+    assert len(outputs) == len(gt)
+    for x, y in zip(outputs, gt):
+        np.testing.assert_allclose(x, y)
 
 
 def test_runner_streaming(
@@ -226,3 +294,32 @@ def test_runner_state(tmp_path: Path) -> None:
     runner.run(np.ones((5, 100)))
     assert runner.state is not None
     assert len(runner.state) == 9
+
+
+def test_runner_error_warnings(tmp_path: Path) -> None:
+    # test warning for asr models when no tokenizer file is present
+    params: Dict[str, Dict[str, Any]] = {
+        "preprocessing": {"tokenizer_file": "does not exist"},
+        "postprocessing": {"tokenizer_file": "does not exist"},
+        "version": {"nengo-edge": version.version},
+        "model": {"type": "asr", "return_sequences": True},
+    }
+
+    interface = gpu.host.Interface(
+        lmu_small(), build_dir=tmp_path, return_sequences=True
+    )
+    interface.export_model(tmp_path)
+    # overwrite exported parameters
+    with open(tmp_path / "parameters.json", "w", encoding="utf-8") as f:
+        json.dump(params, f)
+
+    with pytest.warns(UserWarning, match="cannot decode ASR outputs"):
+        SavedModelRunner(tmp_path)
+
+    # test error for nlp models when no tokenizer file is present
+    params["model"]["type"] = "nlp"
+    with open(tmp_path / "parameters.json", "w", encoding="utf-8") as f:
+        json.dump(params, f)
+
+    with pytest.raises(ValueError, match="required to process string inputs"):
+        SavedModelRunner(tmp_path)

--- a/nengo_edge/version.py
+++ b/nengo_edge/version.py
@@ -11,7 +11,7 @@ unless the code base represents a release version. Release versions are git
 tagged with the version.
 """
 
-version_info = (23, 11, 20)  # bones: ignore
+version_info = (24, 1, 2)  # bones: ignore
 
 name = "nengo-edge"
 dev = 0
@@ -22,4 +22,4 @@ version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev  # pragma: no cover
 
-copyright = "Copyright (c) 2022-2023 Applied Brain Research"
+copyright = "Copyright (c) 2022-2024 Applied Brain Research"


### PR DESCRIPTION
This PR primarily adds support in the `SavedModelRunner` for text/string based inputs during NLP model inference. A new class was also added to `device_modules` named `NetworkTokenizer`, which allows users to make network calls to a device with the SentencePiece CLI installed.